### PR TITLE
Add poster image functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This module is based on the [mediaelement module](https://www.drupal.org/project
   - `File` : *media hosted on your server*.
 
   - `Link` : *media hosted on another domain, i.e. YouTube, Vimeo, etc.*
+  
+  - `Image` : *optional image field to be used as a poster image for MediaElement videos*.
 
 ___
  ![alt](https://github.com/ablank/ablank.github.io/blob/master/imediaelement/fields.png)
@@ -43,6 +45,8 @@ ___
 **Manage Display:** Set the Format to `MediaElement Audio` or `MediaElement Video`
 
   - The Format settings allow you to manage attributes specific to that field (*i.e. width, height, autoplay, etc.*).
+  
+  - To use an image field as a poster image, select the image field to be used and the desired image style in the MediaElement Video format settings.
 
 ___
 

--- a/imediaelement.module
+++ b/imediaelement.module
@@ -81,7 +81,7 @@ function imediaelement_file_mimetype_mapping_alter(&$mapping) {
  * Get default attributes for currently selected skin.
  *
  * @param string $setting
- * 
+ *
  * @return array
  */
 function imediaelement_controls($setting) {
@@ -160,6 +160,10 @@ function imediaelement_field_formatter_info() {
         'download_link' => variable_get('imediaelement_download_link', FALSE),
         'download_text' => variable_get('imediaelement_download_text', t('Download')),
       ),
+      'poster' => array(
+        'poster_image' => variable_get('imediaelement_poster_field', FALSE),
+        'poster_style' => variable_get('imediaelement_poster_style', FALSE),
+      ),
     ),
   );
 
@@ -223,7 +227,7 @@ function imediaelement_field_formatter_view($entity_type, $entity, $field, $inst
       );
 
       // Mabye just map settings ?:
-// array_map('variable_get', array_keys($settings), array_values($settings));
+      // array_map('variable_get', array_keys($settings), array_values($settings));
     }
 
     $class = 'mediaelement-formatter-identifier-' . time() . '-' . $id++;
@@ -272,6 +276,23 @@ function imediaelement_field_formatter_view($entity_type, $entity, $field, $inst
       $element[$delta]['#theme'] = 'imediaelement_video';
       $element[$delta]['#attributes']['height'] = $settings['appearance']['height'];
       $element[$delta]['#attributes']['width'] = $settings['appearance']['width'];
+
+      // Add the poster image.
+      if (($poster_field = $settings['poster']['poster_field']) && !empty($entity->{$poster_field})) {
+        //if (!empty($entity->{$poster_field})) {
+        $image = field_get_items($entity_type, $entity, $poster_field);
+
+        if (isset($image[0]['filemime']) && strpos($image[0]['filemime'], 'image/') !== FALSE) {
+          if ($poster_style = $settings['poster']['poster_style']) {
+            $element[$delta]['#attributes']['poster'] = image_style_url($poster_style, $image[0]['uri']);
+          }
+          else {
+            $element[$delta]['#attributes']['poster'] = file_create_url($image[0]['uri']);
+          }
+        }
+      }
+
+      //$element[$delta]['#attributes']['poster'] = !empty($settings['poster']['poster_style']) ? $settings['poster']['poster_style'] : FALSE;
     }
   }
 
@@ -366,6 +387,12 @@ function imediaelement_markup($variables, $type, $provider = NULL) {
 function imediaelement_field_formatter_settings_form($field, $instance, $view_mode, $form, &$form_state) {
   $display = $instance['display'][$view_mode];
   $settings = $display['settings'];
+  $image_styles = image_style_options(FALSE);
+
+  if (isset($instance['entity_type']) && isset($instance['bundle'])) {
+    $imagefields = _imediaelement_find_image_fields($field, $instance['entity_type'], $instance['bundle']);
+  }
+
   $element = array();
 
   $element['appearance'] = array(
@@ -439,7 +466,7 @@ function imediaelement_field_formatter_settings_form($field, $instance, $view_mo
     '#title' => t('Download Link'),
     '#type' => 'checkbox',
     '#default_value' => $settings['download']['download_link'],
-  // '#attributes' => array('name' => array('opt-download-link')),
+    // '#attributes' => array('name' => array('opt-download-link')),
   );
 
   $element['download']['download_text'] = array(
@@ -448,6 +475,35 @@ function imediaelement_field_formatter_settings_form($field, $instance, $view_mo
     '#default_value' => $settings['download']['download_text'],
     '#size' => 30,
   );
+
+  if (!empty($imagefields)) {
+    $element['poster'] = array(
+      '#title' => t('Poster Image'),
+      '#type' => 'fieldset',
+      '#weight' => 3,
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+    );
+
+    $element['poster']['poster_field'] = array(
+      '#type' => 'select',
+      '#title' => t('Poster Image Field'),
+      '#default_value' => $settings['poster']['poster_field'],
+      '#options' => $imagefields,
+      '#description' => t('If an image is uploaded to the field above it will be used as the poster image.'),
+      '#empty_value' => NULL,
+      '#empty_option' => t('- None -'),
+    );
+
+    $element['poster']['poster_style'] = array(
+      '#title' => t('Poster Image Style'),
+      '#type' => 'select',
+      '#default_value' => $settings['poster']['poster_style'],
+      '#empty_option' => t('None (original image)'),
+      '#description' => t('The original video thumbnail will be displayed. Otherwise, you can add a custom image style at !settings.', array('!settings' => l(t('media image styles'), 'admin/config/media/image-styles'))),
+      '#options' => $image_styles,
+    );
+  }
 
   return $element;
 }
@@ -541,4 +597,76 @@ function imediaelement_help($path, $arg) {
 
     return $output;
   }
+}
+
+/**
+ * Finds image fields in the given entity and bundle.
+ *
+ * @param array $field
+ *   Field definition of the video field, used to match image fields when
+ *   this field is rendered using Views.
+ * @param string $entity_type
+ *   Entity type in which the image field must occur.
+ * @param string $bundle
+ *   Bundle in which the image field must occur.
+ *
+ * @return array
+ *   Array of image field names.
+ */
+function _imediaelement_find_image_fields($field, $entity_type, $bundle) {
+  $imagefields = array();
+
+  // Determine the image fields that will be selectable.
+  if ($entity_type === 'ctools' && $bundle === 'ctools') {
+    // This is a fake instance (see ctools_fields_fake_field_instance()).
+    // This occurs for instance when this formatter is used in Views.
+    // Display all image fields in bundles that contain this field.
+    $otherfields = field_info_fields();
+
+    foreach ($otherfields as $otherfield) {
+      if ($otherfield['type'] === 'image' && !empty($otherfield['bundles'])) {
+        // Find a label by finding an instance label.
+        $instancelabels = array();
+        $bundles_names = array();
+
+        foreach ($otherfield['bundles'] as $otherentitytype => $otherbundles) {
+          foreach ($otherbundles as $otherbundle) {
+            // Check if this image field appears in one of the video field
+            // bundles.
+            if (isset($field['bundles'][$otherentitytype])
+              && in_array($otherbundle, $field['bundles'][$otherentitytype])) {
+              $otherinstance = field_info_instance($otherentitytype, $otherfield['field_name'], $otherbundle);
+              $instancelabels[$otherinstance['label']] = isset($instancelabels[$otherinstance['label']]) ?
+                $instancelabels[$otherinstance['label']] + 1 : 1;
+              $bundles_names[] = t('@entity:@bundle', array(
+                '@entity' => $otherentitytype,
+                '@bundle' => $otherbundle,
+              ));
+            }
+          }
+        }
+
+        if (!empty($instancelabels)) {
+          arsort($instancelabels);
+          $instancelabel = key($instancelabels);
+          $imagefields[$otherfield['field_name']] = $instancelabel . ' — ' . t('Appears in: @bundles.', array(
+            '@bundles' => implode(', ', $bundles_names),
+          ));
+        }
+      }
+    }
+  }
+  else {
+    $otherinstances = field_info_instances($entity_type, $bundle);
+
+    foreach ($otherinstances as $otherinstance) {
+      $otherfield = field_info_field_by_id($otherinstance['field_id']);
+
+      if ($otherfield['type'] == 'image') {
+        $imagefields[$otherinstance['field_name']] = $otherinstance['label'];
+      }
+    }
+  }
+
+  return $imagefields;
 }


### PR DESCRIPTION
Adds functionality for MediaElement video poster images. 

Borrowed and tweaked some code from the [Video.js module](https://www.drupal.org/project/videojs) for this.
